### PR TITLE
Added Collect CRM Core tests patch

### DIFF
--- a/project.make
+++ b/project.make
@@ -71,6 +71,10 @@ projects[tmgmt_mygengo][version] = "1.x-dev"
 projects[views_custom_cache_tag][version] = "1.x-dev"
 projects[wysiwyg_linebreaks][version] = "1.x-dev"
 
+; Module patches.
+; Adds Collect CRM Core tests.
+projects[collect][patch][] = https://raw.githubusercontent.com/fantastic91/CRM-Core-Collect-tests/master/crm-core-collect-tests.patch
+
 ; Unofficial ports.
 projects[block_class][type] = "module"
 projects[block_class][download][type] = "git"


### PR DESCRIPTION
Couldn't add patch URL from Drupal.org as it will be different when we upload the new (test) patch. 

Instead, I added a URL to .patch file which I am going to update every time we update the tests.  

Btw, I can move it to MDS repository too. :)
